### PR TITLE
Use standard gem from Gemfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.5-alpine
+FROM ruby:2.7.4-alpine
 
 RUN apk add --update build-base git
 

--- a/lib/entrypoint.sh
+++ b/lib/entrypoint.sh
@@ -2,6 +2,8 @@
 
 set -e
 
-gem install standard
+bundle config set --local with 'ci'
+bundle config set --local without 'default development test'
+bundle install
 
 ruby /action/lib/index.rb


### PR DESCRIPTION
I was recently running StandardRB on our codebase locally and noticed that the output was different to that of CI. Turns out it was happening because the action just does a `gem install standard` whilst development uses the version pinned in the `Gemfile.lock`. I bumped our version of standard in development and output was then consistent between environments.

That was a temporary fix, because as new standard gems are released we would get the same issue again, but we wouldn't be alerted of that fact and would get weird failures.

Things change does two things:

1) Instead of doing a `gem install` we install the version from our `Gemfile` which will always be the same version in development.

2) Because we install the gem from the `Gemfile` the Ruby version specified there must be what we use to install `standard`. This will cause us maintenance when we upgrade Ruby, but the good thing is that this check will fail, and we will be alerted to the fact Ruby version in the `Dockerfile` needs bumping.
